### PR TITLE
Upstream/cached mapping

### DIFF
--- a/camkes-linux-artifacts/camkes-linux-modules/camkes-connector-modules/connection/connection.c
+++ b/camkes-linux-artifacts/camkes-linux-modules/camkes-connector-modules/connection/connection.c
@@ -101,7 +101,7 @@ static int connector_pci_probe(struct pci_dev *dev,
             break;
         }
         uio->mem[i].size = pci_resource_len(dev, i);
-        uio->mem[i].memtype = UIO_MEM_PHYS;
+        uio->mem[i].memtype = UIO_MEM_IOVA;
 
         last_bar = i;
     }


### PR DESCRIPTION
Changing the mapping to cached here and in global-components make ARM and x86 work the same way. Additionally, things like vm_introspect in camkes-vm-examples might have been a bit broken. I modified that example to have a CAmkES dataport, on one VM the dataport pages mapped as VM's RAM and on the another VM they were exposed to QEMU running in guest Linux via this kernel module. Despite the PIPT data caches, I found the contents do not match sometimes.

I tracked this down to components having both non-cached and cached accesses to dataport memory and hence set forth to make the mappings cached on ARM as well.

Test with: https://github.com/seL4/global-components/pull/32