### PR TITLE
helpers, trivial: update arch size check

### DIFF
--- a/vm-linux-helpers.cmake
+++ b/vm-linux-helpers.cmake
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.8.2)
 RequireFile(UPDATE_INITRD_ROOTFS_PATH update_dtb_initrd.py PATHS "${CMAKE_CURRENT_LIST_DIR}/tools")
 set(VM_LINUX_PROJECT_DIR "${CMAKE_CURRENT_LIST_DIR}" CACHE INTERNAL "")
-if(KernelSel4ArchX86_64)
+if(KernelX86_64VTX64BitGuests)
     set(arch_size_dir "64")
 else()
     set(arch_size_dir "32")


### PR DESCRIPTION
64-bit guest behavior is enabled when KernelX86_64VTX64BitGuests is enabled, not when KernelSel4ArchX86_64 is.